### PR TITLE
Encoding problem in the output files

### DIFF
--- a/src/Talifun.Web/Helper/RetryableFileWriter.cs
+++ b/src/Talifun.Web/Helper/RetryableFileWriter.cs
@@ -9,12 +9,14 @@ namespace Talifun.Web.Helper
         protected readonly int BufferSize;
         protected readonly IRetryableFileOpener RetryableFileOpener;
         protected readonly IHasher Hasher;
+        private readonly Encoding _encoding;
 
         public RetryableFileWriter(int bufferSize, IRetryableFileOpener retryableFileOpener, IHasher hasher)
         {
             BufferSize = bufferSize;
             RetryableFileOpener = retryableFileOpener;
             Hasher = hasher;
+            _encoding = Encoding.UTF8;
         }
 
         /// <summary>
@@ -26,8 +28,7 @@ namespace Talifun.Web.Helper
         {
             using (var outputStream = new MemoryStream())
             {
-                var uniEncoding = Encoding.Default;
-                outputStream.Write(uniEncoding.GetBytes(output), 0, uniEncoding.GetByteCount(output));
+                outputStream.Write(_encoding.GetBytes(output), 0, _encoding.GetByteCount(output));
 
                 return SaveContentsToFile(outputStream, outputPath);
             }
@@ -42,10 +43,9 @@ namespace Talifun.Web.Helper
         {
             using (var outputStream = new MemoryStream())
             {
-                var uniEncoding = Encoding.Default;
                 var uncompressedContent = output.ToString();
 
-                outputStream.Write(uniEncoding.GetBytes(uncompressedContent), 0, uniEncoding.GetByteCount(uncompressedContent));
+                outputStream.Write(_encoding.GetBytes(uncompressedContent), 0, _encoding.GetByteCount(uncompressedContent));
 
                 return SaveContentsToFile(outputStream, outputPath);
             }


### PR DESCRIPTION
Hi,

When testing with our multinational solution, we noticed that the output files were not encoded correctly to allow cyrillic characters.

On investigation, I noticed that the reading of the files was explicitly using UTF8 encoding, but the writing of the files (in the RetryableFileWriter) was using Encoding.Default, which uses the system code page.

I have changed the encoding to UTF8, and moved the initialisation to the constructor, so if it needs changing again it only needs to be done in one place.

Thanks

Richard
