### PR TITLE
Due copyright notices

### DIFF
--- a/src/Talifun.Web/Module/DictionaryExtensions.cs
+++ b/src/Talifun.Web/Module/DictionaryExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region License, Terms and Author(s)
+//
+// ELMAH - Error Logging Modules and Handlers for ASP.NET
+// Copyright (c) 2004-9 Atif Aziz. All rights reserved.
+//
+//  Author(s):
+//
+//      Atif Aziz, http://www.raboof.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 

--- a/src/Talifun.Web/Module/HttpModuleBase.cs
+++ b/src/Talifun.Web/Module/HttpModuleBase.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿#region License, Terms and Author(s)
+//
+// ELMAH - Error Logging Modules and Handlers for ASP.NET
+// Copyright (c) 2004-9 Atif Aziz. All rights reserved.
+//
+//  Author(s):
+//
+//      Atif Aziz, http://www.raboof.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
 using System.Web;
 
 namespace Talifun.Web.Module


### PR DESCRIPTION
Thanks for maintaining the [original copyright notice in `HttpModuleRegistry.cs`](https://github.com/taliesins/talifun-web/blob/15d519a21c295fe0566c1902f7b1d9c2e189365a/src/Talifun.Web/Module/HttpModuleRegistry.cs) as per [Apache License 2.0 terms](https://bitbucket.org/project-elmah/main/src/f9272c55dcfd0f6f09249719529c0f3e075502c2/COPYING.txt?at=default&fileviewer=file-view-default), but I noticed that [`DictionaryExtensions.cs`](https://github.com/taliesins/talifun-web/blob/15d519a21c295fe0566c1902f7b1d9c2e189365a/src/Talifun.Web/Module/DictionaryExtensions.cs) and [`HttpModuleBase.cs`](https://github.com/taliesins/talifun-web/blob/15d519a21c295fe0566c1902f7b1d9c2e189365a/src/Talifun.Web/Module/HttpModuleBase.cs) were missing the same so this PR is to help fix that. And thanks otherwise for a great project.
